### PR TITLE
llm이 url을 헷갈리지 않도록 다른 url 메타데이터 들어오지 못하게 주석처리

### DIFF
--- a/src/estalan/tools/search.py
+++ b/src/estalan/tools/search.py
@@ -351,16 +351,16 @@ class GoogleSerperImageSearchResult(BaseGoogleSerperResult):
                 continue
             metadata = {
                 "title": result["title"],
-                "link": result["link"],
+                # "link": result["link"],
                 "image_url": result["imageUrl"],
                 "imageWidth": result.get("imageWidth"),
                 "imageHeight": result.get("imageHeight"),
-                "thumbnail_url": result.get("thumbnailUrl"),
-                "thumbnailWidth": result.get("thumbnailWidth"),
-                "thumbnailHeight": result.get("thumbnailHeight"),
+                # "thumbnail_url": result.get("thumbnailUrl"),
+                # "thumbnailWidth": result.get("thumbnailWidth"),
+                # "thumbnailHeight": result.get("thumbnailHeight"),
                 "domain": result.get("domain"),
                 "source": result.get("source"),
-                "google_url": result.get("googleUrl"),
+                # "google_url": result.get("googleUrl"),
                 "position": result.get("position"),
                 "type": "image",
             }


### PR DESCRIPTION
llm이 url을 헷갈리지 않도록 다른 url 메타데이터 들어오지 못하게 주석처리
3번정도 테스트 했을 때 모든이미지가 확장자명 .jpg .jpeg .png인 이미지들만 들어왔음